### PR TITLE
chore: sync plugin.json version to latest tag v0.5.3

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-authz",
-    "version": "0.0.0-dev",
+    "version": "0.5.3",
     "description": "RBAC authorization plugin using Casbin",
     "author": "GoCodeAlone",
     "license": "MIT",


### PR DESCRIPTION
Sync the `version` field in `plugin.json` to match the latest git release tag, eliminating drift between the published tag and the manifest the registry/consumers read.

**Change:** `version` field updated to match latest tag.

This is a pure metadata sync — no code changes.