### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,90 +50,23 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
-      - name: Update registry manifest
-        if: success() && env.GH_TOKEN != ''
-        continue-on-error: true
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          PLUGIN_NAME="${GITHUB_REPOSITORY##*/}"
-          REGISTRY_NAME="${PLUGIN_NAME#workflow-plugin-}"
-          REGISTRY_NAME="${REGISTRY_NAME#workflow-}"
-          BASE_URL="https://github.com/GoCodeAlone/${PLUGIN_NAME}/releases/download/v${VERSION}/${PLUGIN_NAME}"
 
-          git clone "https://x-access-token:${REGISTRY_PAT}@github.com/GoCodeAlone/workflow-registry.git" /tmp/workflow-registry
-          cd /tmp/workflow-registry
-
-          MANIFEST="plugins/${REGISTRY_NAME}/manifest.json"
-          if [[ ! -f "${MANIFEST}" ]]; then
-            echo "No manifest found at ${MANIFEST}, skipping registry update."
-            exit 0
-          fi
-
-          jq --arg v "${VERSION}" \
-             --arg base "${BASE_URL}" \
-             '.version = $v |
-              .downloads = [
-                {os: "linux",  arch: "amd64", url: ($base + "-linux-amd64.tar.gz")},
-                {os: "linux",  arch: "arm64", url: ($base + "-linux-arm64.tar.gz")},
-                {os: "darwin", arch: "amd64", url: ($base + "-darwin-amd64.tar.gz")},
-                {os: "darwin", arch: "arm64", url: ($base + "-darwin-arm64.tar.gz")}
-              ]' "${MANIFEST}" > tmp.json && mv tmp.json "${MANIFEST}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH="auto/sync-${PLUGIN_NAME}-v${VERSION}"
-          git checkout -b "${BRANCH}"
-          git add "plugins/${REGISTRY_NAME}/manifest.json"
-          git commit -m "sync: ${PLUGIN_NAME} v${VERSION}"
-          git push "https://x-access-token:${REGISTRY_PAT}@github.com/GoCodeAlone/workflow-registry.git" "${BRANCH}"
-
-          gh pr create \
-            --repo GoCodeAlone/workflow-registry \
-            --head "${BRANCH}" \
-            --base main \
-            --title "sync: ${PLUGIN_NAME} v${VERSION}" \
-            --body "Auto-sync \`${PLUGIN_NAME}\` manifest to v${VERSION}" \
-            --label "auto-sync" || true
-        env:
-          REGISTRY_PAT: ${{ secrets.REGISTRY_PAT }}
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-authz'
     steps:
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
-      - name: Publish GitHub release
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
-          script: |
-            const tag = context.ref.replace('refs/tags/', '');
-            const { owner, repo } = context.repo;
-            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
-            // creates releases as draft; this step flips them to non-draft post-publish.
-            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-            const release = releases.find(r => r.tag_name === tag);
-            if (!release) {
-              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
-            }
-            if (release.draft) {
-              await github.rest.repos.updateRelease({
-                owner,
-                repo,
-                release_id: release.id,
-                draft: false,
-              });
-            }
+          client-payload: |-
+            {"plugin": "authz", "tag": "${{ github.ref_name }}"}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,40 @@ jobs:
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
 
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish GitHub release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const { owner, repo } = context.repo;
+            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
+            // creates releases as draft; this step flips them to non-draft post-publish.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const release = releases.find(r => r.tag_name === tag);
+            if (!release) {
+              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
+            }
+            if (release.draft) {
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.id,
+                draft: false,
+              });
+            }
+
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: release
+    needs: publish-release
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')


### PR DESCRIPTION
Fixes two bugs in the release pipeline:

1. **Dead dispatch payload** — `notify-registry` sent `{"plugin": "GoCodeAlone/workflow-plugin-authz", ...}` but the registry consumer expects a bare plugin name (`"authz"`). Dispatch silently no-op'd on every release.
2. **Regressing direct manifest-write** — the `release` job cloned `workflow-registry` and overwrote `plugins/authz/manifest.json` directly, bypassing the canonical `plugin-release` dispatch path and using the deprecated `REGISTRY_PAT` secret.

**Changes:**
- Removes `notify-registry` job entirely.
- Removes the inline "Update registry manifest" step from the `release` job.
- Adds fleet-canonical `notify-workflow-registry` job: `repo_dispatch_token`, pinned SHA (`peter-evans/repository-dispatch@28959ce8...` v4), bare-name payload `{"plugin": "authz", "tag": "..."}`, pre-release guard.