### PR TITLE
chore: apply plugin version discipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+      - name: Verify shipped plugin.json carries tag (post-build)
+        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir . ."
 
   publish-release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-authz",
-    "version": "0.5.8",
+    "version": "0.0.0",
     "description": "RBAC authorization plugin using Casbin",
     "author": "GoCodeAlone",
     "license": "MIT",


### PR DESCRIPTION
Part of GoCodeAlone/workflow#760.\n\nChanges:\n- keep committed plugin.json.version at the 0.0.0 development sentinel\n- add post-build release validation so the shipped manifest is checked against the tag\n\nVerification:\n- wfctl plugin validate-contract .\n- wfctl plugin validate-contract --for-publish --tag v9.9.9 .\n- GOWORK=off go test ./...