### PR TITLE
Expose public authz plugin constructor

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,12 @@
+// Package workflowpluginauthz provides the authz workflow plugin.
+package workflowpluginauthz
+
+import (
+	"github.com/GoCodeAlone/workflow-plugin-authz/internal"
+	"github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+// NewAuthzPlugin returns the authz SDK plugin provider.
+func NewAuthzPlugin() sdk.PluginProvider {
+	return internal.NewAuthzPlugin()
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,21 @@
+package workflowpluginauthz_test
+
+import (
+	"testing"
+
+	workflowpluginauthz "github.com/GoCodeAlone/workflow-plugin-authz"
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+func TestNewAuthzPluginIsPubliclyImportable(t *testing.T) {
+	plugin := workflowpluginauthz.NewAuthzPlugin()
+	if plugin == nil {
+		t.Fatal("NewAuthzPlugin() returned nil")
+	}
+	if _, ok := plugin.(sdk.ModuleProvider); !ok {
+		t.Fatal("NewAuthzPlugin() must expose authz module providers")
+	}
+	if _, ok := plugin.(sdk.StepProvider); !ok {
+		t.Fatal("NewAuthzPlugin() must expose authz step providers")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a root package wrapper exposing `NewAuthzPlugin()` for consumers that embed the authz SDK provider.

## Test
- `GOWORK=off go test ./...`