### PR TITLE
feat: add reusable authz admin API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ RBAC authorization plugin for the [workflow engine](https://github.com/GoCodeAlo
 | Step | `step.authz_remove_policy` |
 | Step | `step.authz_role_assign` |
 
+## Reusable admin API
+
+Go hosts can mount the provider-neutral admin backend from `adminapi.NewHandler`
+instead of rebuilding authz JSON routes per application. The package serves the
+route contract consumed by `workflow-plugin-authz-ui`:
+
+- `/api/authz/roles`
+- `/api/authz/scopes`
+- `/api/authz/capabilities`
+- `/api/authz/declarations`
+- `/api/authz/projection-inputs`
+- `/api/authz/model`
+- `/api/authz/policies`
+- `/api/authz/abac/policies`
+- `/api/authz/rebac/tuples`
+- `/api/authz/rebac/check`
+- `/api/authz/enforce`
+
+The host supplies typed adapters for principal resolution, authorization, and
+provider data. Enforcement remains server-side: the handler authorizes the
+authenticated principal for each backend action before reading request bodies or
+calling the provider. Client-supplied subjects are decision inputs, not proof of
+authority.
+
+```go
+handler, err := adminapi.NewHandler(adminapi.Options{
+    BasePath:          "/api/v1/admin/authz",
+    PrincipalResolver: hostPrincipalResolver,
+    Authorizer:        hostAuthorizer,
+    Provider:          hostAuthzProvider,
+})
+```
+
 ## authz.casbin module
 
 Loads a Casbin PERM model and policy from inline YAML config. The enforcer is thread-safe and shared with all `step.authz_check_casbin` steps that reference the module by name.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ RBAC authorization plugin for the [workflow engine](https://github.com/GoCodeAlo
 
 Go hosts can mount the provider-neutral admin backend from `adminapi.NewHandler`
 instead of rebuilding authz JSON routes per application. The package serves the
-route contract consumed by `workflow-plugin-authz-ui`:
+route contract consumed by `workflow-plugin-authz-ui` under `Options.BasePath`
+(default `/api/authz`):
 
 - `/api/authz/roles`
 - `/api/authz/scopes`

--- a/adminapi/handler.go
+++ b/adminapi/handler.go
@@ -25,7 +25,42 @@ func NewHandler(options Options) (http.Handler, error) {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	requestPath := cleanPath(r.URL.Path)
+	if route, ok := h.routes.ByPath[r.Method+" "+requestPath]; ok {
+		h.dispatch(w, r, route)
+		return
+	}
+	if h.isAdminAPIPath(requestPath) {
+		if allow := h.allowedMethods(requestPath); len(allow) > 0 {
+			w.Header().Set("Allow", strings.Join(allow, ", "))
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
 	h.mux.ServeHTTP(w, r)
+}
+
+func (h *handler) isAdminAPIPath(requestPath string) bool {
+	basePath := h.options.BasePath
+	return requestPath == basePath || strings.HasPrefix(requestPath, basePath+"/")
+}
+
+func (h *handler) allowedMethods(requestPath string) []string {
+	known := map[string]bool{}
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if _, ok := h.routes.ByPath[method+" "+requestPath]; ok {
+			known[method] = true
+		}
+	}
+	methods := make([]string, 0, len(known))
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if known[method] {
+			methods = append(methods, method)
+		}
+	}
+	return methods
 }
 
 func (c RouteCatalog) install(h *handler) {

--- a/adminapi/handler.go
+++ b/adminapi/handler.go
@@ -1,0 +1,188 @@
+package adminapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+)
+
+type handler struct {
+	options Options
+	routes  RouteCatalog
+	mux     *http.ServeMux
+}
+
+func NewHandler(options Options) (http.Handler, error) {
+	options = normalizeOptions(options)
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+	h := &handler{options: options, routes: RoutesForBasePath(options.BasePath), mux: http.NewServeMux()}
+	h.routes.install(h)
+	return h, nil
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mux.ServeHTTP(w, r)
+}
+
+func (c RouteCatalog) install(h *handler) {
+	for _, route := range c.ByPath {
+		route := route
+		h.mux.HandleFunc(route.Path, func(w http.ResponseWriter, r *http.Request) {
+			h.dispatch(w, r, route)
+		})
+	}
+}
+
+func DefaultRoutes() RouteCatalog {
+	return RoutesForBasePath("/api/authz")
+}
+
+func RoutesForBasePath(basePath string) RouteCatalog {
+	basePath = cleanPath(basePath)
+	routes := []Route{
+		{Name: "roles", Method: http.MethodGet, Path: basePath + "/roles", Resource: "authz.roles", Action: "read"},
+		{Name: "scopes", Method: http.MethodGet, Path: basePath + "/scopes", Resource: "authz.scopes", Action: "read"},
+		{Name: "capabilities", Method: http.MethodGet, Path: basePath + "/capabilities", Resource: "authz.capabilities", Action: "read"},
+		{Name: "declarations", Method: http.MethodGet, Path: basePath + "/declarations", Resource: "authz.declarations", Action: "read"},
+		{Name: "projection-inputs", Method: http.MethodGet, Path: basePath + "/projection-inputs", Resource: "authz.projection", Action: "read"},
+		{Name: "model", Method: http.MethodGet, Path: basePath + "/model", Resource: "authz.model", Action: "read"},
+		{Name: "policies", Method: http.MethodGet, Path: basePath + "/policies", Resource: "authz.policies", Action: "read"},
+		{Name: "abac-policies", Method: http.MethodGet, Path: basePath + "/abac/policies", Resource: "authz.abac.policies", Action: "read"},
+		{Name: "rebac-tuples", Method: http.MethodGet, Path: basePath + "/rebac/tuples", Resource: "authz.rebac.tuples", Action: "read"},
+		{Name: "rebac-check", Method: http.MethodPost, Path: basePath + "/rebac/check", Resource: "authz.rebac", Action: "check"},
+		{Name: "enforce", Method: http.MethodPost, Path: basePath + "/enforce", Resource: "authz.decisions", Action: "enforce"},
+	}
+	byPath := make(map[string]Route, len(routes))
+	for _, route := range routes {
+		byPath[route.Path] = route
+	}
+	return RouteCatalog{ByPath: byPath}
+}
+
+func normalizeOptions(options Options) Options {
+	if strings.TrimSpace(options.BasePath) == "" {
+		options.BasePath = "/api/authz"
+	}
+	options.BasePath = cleanPath(options.BasePath)
+	return options
+}
+
+func (o Options) validate() error {
+	var missing []string
+	if o.PrincipalResolver == nil {
+		missing = append(missing, "PrincipalResolver")
+	}
+	if o.Authorizer == nil {
+		missing = append(missing, "Authorizer")
+	}
+	if o.Provider == nil {
+		missing = append(missing, "Provider")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("adminapi: missing required adapters: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (h *handler) dispatch(w http.ResponseWriter, r *http.Request, route Route) {
+	if r.Method != route.Method {
+		w.Header().Set("Allow", route.Method)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	principal, ok := h.options.PrincipalResolver.CurrentPrincipal(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if err := h.options.Authorizer.Authorize(r.Context(), principal, route.Resource, route.Action); err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	h.serveRoute(w, r, principal, route)
+}
+
+func (h *handler) serveRoute(w http.ResponseWriter, r *http.Request, principal Principal, route Route) {
+	switch route.Name {
+	case "roles":
+		items, err := h.options.Provider.Roles(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"roles": items}, err)
+	case "scopes":
+		items, err := h.options.Provider.Scopes(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"scopes": items}, err)
+	case "capabilities":
+		items, err := h.options.Provider.Capabilities(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"capabilities": items}, err)
+	case "declarations":
+		items, err := h.options.Provider.Declarations(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"declarations": items}, err)
+	case "projection-inputs":
+		items, err := h.options.Provider.ProjectionInputs(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"projection_inputs": items}, err)
+	case "model":
+		item, err := h.options.Provider.Model(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"model": item}, err)
+	case "policies":
+		items, err := h.options.Provider.Policies(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"policies": items}, err)
+	case "abac-policies":
+		items, err := h.options.Provider.AttributePolicies(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"policies": items}, err)
+	case "rebac-tuples":
+		items, err := h.options.Provider.RelationTuples(r.Context(), principal)
+		writeProviderResult(w, map[string]any{"tuples": items}, err)
+	case "rebac-check":
+		var input RelationCheck
+		if err := decodeJSON(r, &input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		decision, err := h.options.Provider.CheckRelation(r.Context(), principal, input)
+		writeProviderResult(w, decision, err)
+	case "enforce":
+		var input DecisionRequest
+		if err := decodeJSON(r, &input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		decision, err := h.options.Provider.Enforce(r.Context(), principal, input)
+		writeProviderResult(w, decision, err)
+	default:
+		writeError(w, http.StatusNotFound, "not found")
+	}
+}
+
+func writeProviderResult(w http.ResponseWriter, payload any, err error) {
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "authz provider unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func decodeJSON(r *http.Request, out any) error {
+	defer r.Body.Close()
+	return json.NewDecoder(r.Body).Decode(out)
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]any{"error": message})
+}
+
+func cleanPath(value string) string {
+	clean := path.Clean("/" + strings.Trim(strings.TrimSpace(value), "/"))
+	if clean == "/" {
+		return ""
+	}
+	return clean
+}

--- a/adminapi/handler.go
+++ b/adminapi/handler.go
@@ -29,10 +29,27 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c RouteCatalog) install(h *handler) {
-	for _, route := range c.ByPath {
-		route := route
-		h.mux.HandleFunc(route.Path, func(w http.ResponseWriter, r *http.Request) {
-			h.dispatch(w, r, route)
+	routesByPath := make(map[string][]Route)
+	for key, route := range c.ByPath {
+		if strings.Contains(key, " ") {
+			routesByPath[route.Path] = append(routesByPath[route.Path], route)
+		}
+	}
+	for routePath, routes := range routesByPath {
+		routes := routes
+		h.mux.HandleFunc(routePath, func(w http.ResponseWriter, r *http.Request) {
+			for _, route := range routes {
+				if route.Method == r.Method {
+					h.dispatch(w, r, route)
+					return
+				}
+			}
+			allow := make([]string, 0, len(routes))
+			for _, route := range routes {
+				allow = append(allow, route.Method)
+			}
+			w.Header().Set("Allow", strings.Join(allow, ", "))
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		})
 	}
 }
@@ -45,20 +62,31 @@ func RoutesForBasePath(basePath string) RouteCatalog {
 	basePath = cleanPath(basePath)
 	routes := []Route{
 		{Name: "roles", Method: http.MethodGet, Path: basePath + "/roles", Resource: "authz.roles", Action: "read"},
+		{Name: "roles-upsert", Method: http.MethodPost, Path: basePath + "/roles", Resource: "authz.roles", Action: "update"},
+		{Name: "roles-delete", Method: http.MethodDelete, Path: basePath + "/roles", Resource: "authz.roles", Action: "update"},
 		{Name: "scopes", Method: http.MethodGet, Path: basePath + "/scopes", Resource: "authz.scopes", Action: "read"},
 		{Name: "capabilities", Method: http.MethodGet, Path: basePath + "/capabilities", Resource: "authz.capabilities", Action: "read"},
 		{Name: "declarations", Method: http.MethodGet, Path: basePath + "/declarations", Resource: "authz.declarations", Action: "read"},
 		{Name: "projection-inputs", Method: http.MethodGet, Path: basePath + "/projection-inputs", Resource: "authz.projection", Action: "read"},
 		{Name: "model", Method: http.MethodGet, Path: basePath + "/model", Resource: "authz.model", Action: "read"},
 		{Name: "policies", Method: http.MethodGet, Path: basePath + "/policies", Resource: "authz.policies", Action: "read"},
+		{Name: "policies-upsert", Method: http.MethodPost, Path: basePath + "/policies", Resource: "authz.policies", Action: "update"},
+		{Name: "policies-delete", Method: http.MethodDelete, Path: basePath + "/policies", Resource: "authz.policies", Action: "update"},
 		{Name: "abac-policies", Method: http.MethodGet, Path: basePath + "/abac/policies", Resource: "authz.abac.policies", Action: "read"},
+		{Name: "abac-policies-upsert", Method: http.MethodPost, Path: basePath + "/abac/policies", Resource: "authz.abac.policies", Action: "update"},
+		{Name: "abac-policies-delete", Method: http.MethodDelete, Path: basePath + "/abac/policies", Resource: "authz.abac.policies", Action: "update"},
 		{Name: "rebac-tuples", Method: http.MethodGet, Path: basePath + "/rebac/tuples", Resource: "authz.rebac.tuples", Action: "read"},
+		{Name: "rebac-tuples-upsert", Method: http.MethodPost, Path: basePath + "/rebac/tuples", Resource: "authz.rebac.tuples", Action: "update"},
+		{Name: "rebac-tuples-delete", Method: http.MethodDelete, Path: basePath + "/rebac/tuples", Resource: "authz.rebac.tuples", Action: "update"},
 		{Name: "rebac-check", Method: http.MethodPost, Path: basePath + "/rebac/check", Resource: "authz.rebac", Action: "check"},
 		{Name: "enforce", Method: http.MethodPost, Path: basePath + "/enforce", Resource: "authz.decisions", Action: "enforce"},
 	}
-	byPath := make(map[string]Route, len(routes))
+	byPath := make(map[string]Route, len(routes)*2)
 	for _, route := range routes {
-		byPath[route.Path] = route
+		byPath[route.Method+" "+route.Path] = route
+		if _, exists := byPath[route.Path]; !exists || route.Method == http.MethodGet {
+			byPath[route.Path] = route
+		}
 	}
 	return RouteCatalog{ByPath: byPath}
 }
@@ -110,31 +138,79 @@ func (h *handler) serveRoute(w http.ResponseWriter, r *http.Request, principal P
 	switch route.Name {
 	case "roles":
 		items, err := h.options.Provider.Roles(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"roles": items}, err)
+		writeProviderResult(w, items, err)
+	case "roles-upsert":
+		var input RoleAssignment
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.UpsertRole(r.Context(), principal, input))
+	case "roles-delete":
+		var input RoleAssignment
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.DeleteRole(r.Context(), principal, input))
 	case "scopes":
 		items, err := h.options.Provider.Scopes(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"scopes": items}, err)
+		writeProviderResult(w, items, err)
 	case "capabilities":
 		items, err := h.options.Provider.Capabilities(r.Context(), principal)
 		writeProviderResult(w, map[string]any{"capabilities": items}, err)
 	case "declarations":
 		items, err := h.options.Provider.Declarations(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"declarations": items}, err)
+		writeProviderResult(w, items, err)
 	case "projection-inputs":
 		items, err := h.options.Provider.ProjectionInputs(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"projection_inputs": items}, err)
+		writeProviderResult(w, items, err)
 	case "model":
 		item, err := h.options.Provider.Model(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"model": item}, err)
+		writeProviderResult(w, item, err)
 	case "policies":
 		items, err := h.options.Provider.Policies(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"policies": items}, err)
+		writeProviderResult(w, items, err)
+	case "policies-upsert":
+		var input PolicyRule
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.UpsertPolicy(r.Context(), principal, input))
+	case "policies-delete":
+		var input PolicyRule
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.DeletePolicy(r.Context(), principal, input))
 	case "abac-policies":
 		items, err := h.options.Provider.AttributePolicies(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"policies": items}, err)
+		writeProviderResult(w, items, err)
+	case "abac-policies-upsert":
+		var input AttributePolicy
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.UpsertAttributePolicy(r.Context(), principal, input))
+	case "abac-policies-delete":
+		var input AttributePolicy
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.DeleteAttributePolicy(r.Context(), principal, input))
 	case "rebac-tuples":
 		items, err := h.options.Provider.RelationTuples(r.Context(), principal)
-		writeProviderResult(w, map[string]any{"tuples": items}, err)
+		writeProviderResult(w, items, err)
+	case "rebac-tuples-upsert":
+		var input RelationTuple
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.UpsertRelationTuple(r.Context(), principal, input))
+	case "rebac-tuples-delete":
+		var input RelationTuple
+		if !decodeRouteJSON(w, r, &input) {
+			return
+		}
+		writeProviderResult(w, map[string]any{"changed": true}, h.options.Provider.DeleteRelationTuple(r.Context(), principal, input))
 	case "rebac-check":
 		var input RelationCheck
 		if err := decodeJSON(r, &input); err != nil {
@@ -154,6 +230,14 @@ func (h *handler) serveRoute(w http.ResponseWriter, r *http.Request, principal P
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}
+}
+
+func decodeRouteJSON(w http.ResponseWriter, r *http.Request, out any) bool {
+	if err := decodeJSON(r, out); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return false
+	}
+	return true
 }
 
 func writeProviderResult(w http.ResponseWriter, payload any, err error) {

--- a/adminapi/handler_test.go
+++ b/adminapi/handler_test.go
@@ -1,0 +1,238 @@
+package adminapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRouteCatalogContainsAuthzUIBackendEndpoints(t *testing.T) {
+	routes := DefaultRoutes()
+	for _, want := range []string{
+		"/api/authz/roles",
+		"/api/authz/scopes",
+		"/api/authz/capabilities",
+		"/api/authz/declarations",
+		"/api/authz/projection-inputs",
+		"/api/authz/model",
+		"/api/authz/policies",
+		"/api/authz/abac/policies",
+		"/api/authz/rebac/tuples",
+		"/api/authz/rebac/check",
+		"/api/authz/enforce",
+	} {
+		if _, ok := routes.ByPath[want]; !ok {
+			t.Fatalf("route catalog missing %s; routes=%#v", want, routes.ByPath)
+		}
+	}
+}
+
+func TestNewHandlerRequiresPrincipalResolverAndAuthorizer(t *testing.T) {
+	_, err := NewHandler(Options{})
+	if err == nil {
+		t.Fatal("NewHandler without auth adapters succeeded")
+	}
+	for _, want := range []string{"PrincipalResolver", "Authorizer"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %s", err.Error(), want)
+		}
+	}
+}
+
+func TestHandlerDeniesUnauthenticatedAndUnauthorizedRequests(t *testing.T) {
+	h, err := NewHandler(Options{
+		PrincipalResolver: noPrincipal{},
+		Authorizer:        allowAuthorizer{},
+		Provider:          testProvider{},
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/authz/roles", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", rec.Code)
+	}
+
+	h, err = NewHandler(Options{
+		PrincipalResolver: fixedPrincipal{Principal{Subject: "user-1"}},
+		Authorizer:        denyAuthorizer{},
+		Provider:          testProvider{},
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/authz/roles", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unauthorized status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHandlerServesRolesScopesCapabilitiesAndDeclarations(t *testing.T) {
+	h := newTestHandler(t)
+
+	for _, tc := range []struct {
+		path string
+		key  string
+	}{
+		{"/api/authz/roles", "roles"},
+		{"/api/authz/scopes", "scopes"},
+		{"/api/authz/capabilities", "capabilities"},
+		{"/api/authz/declarations", "declarations"},
+		{"/api/authz/projection-inputs", "projection_inputs"},
+		{"/api/authz/model", "model"},
+		{"/api/authz/policies", "policies"},
+		{"/api/authz/abac/policies", "policies"},
+		{"/api/authz/rebac/tuples", "tuples"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("decode JSON: %v", err)
+			}
+			if _, ok := payload[tc.key]; !ok {
+				t.Fatalf("response for %s missing key %q: %s", tc.path, tc.key, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandlerEnforceUsesProviderDecision(t *testing.T) {
+	h := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/authz/enforce", strings.NewReader(`{"subject":"user-1","resource":"cms.page","action":"read","context":"tenant:blackorchid"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Allowed bool   `json:"allowed"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if !payload.Allowed || payload.Reason != "matched test rule" {
+		t.Fatalf("payload = %#v, want allowed test decision", payload)
+	}
+}
+
+func TestHandlerRejectsClientAssertedSubjectWithoutPermission(t *testing.T) {
+	h, err := NewHandler(Options{
+		PrincipalResolver: fixedPrincipal{Principal{Subject: "user-1"}},
+		Authorizer:        actionDenyAuthorizer{denyAction: "enforce"},
+		Provider:          testProvider{},
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/authz/enforce", strings.NewReader(`{"subject":"super-admin","resource":"cms.page","action":"delete"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func newTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+	h, err := NewHandler(Options{
+		PrincipalResolver: fixedPrincipal{Principal{Subject: "admin-1"}},
+		Authorizer:        allowAuthorizer{},
+		Provider:          testProvider{},
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h
+}
+
+type noPrincipal struct{}
+
+func (noPrincipal) CurrentPrincipal(*http.Request) (Principal, bool) { return Principal{}, false }
+
+type fixedPrincipal struct{ principal Principal }
+
+func (r fixedPrincipal) CurrentPrincipal(*http.Request) (Principal, bool) {
+	return r.principal, true
+}
+
+type allowAuthorizer struct{}
+
+func (allowAuthorizer) Authorize(context.Context, Principal, string, string) error { return nil }
+
+type denyAuthorizer struct{}
+
+func (denyAuthorizer) Authorize(context.Context, Principal, string, string) error {
+	return errors.New("denied")
+}
+
+type actionDenyAuthorizer struct{ denyAction string }
+
+func (a actionDenyAuthorizer) Authorize(_ context.Context, _ Principal, _ string, action string) error {
+	if action == a.denyAction {
+		return errors.New("denied")
+	}
+	return nil
+}
+
+type testProvider struct{}
+
+func (testProvider) Roles(context.Context, Principal) ([]Role, error) {
+	return []Role{{Name: "tenant_admin", Scopes: []string{"cms.page.read"}}}, nil
+}
+
+func (testProvider) Scopes(context.Context, Principal) ([]Scope, error) {
+	return []Scope{{Name: "cms.page.read", Resource: "cms.page", Action: "read"}}, nil
+}
+
+func (testProvider) Capabilities(context.Context, Principal) ([]Capability, error) {
+	return []Capability{{Name: "rbac", Supported: true}}, nil
+}
+
+func (testProvider) Declarations(context.Context, Principal) (Declarations, error) {
+	return Declarations{Resources: []ResourceDeclaration{{Name: "cms.page", Actions: []string{"read"}}}}, nil
+}
+
+func (testProvider) ProjectionInputs(context.Context, Principal) (ProjectionInputs, error) {
+	return ProjectionInputs{Subject: "admin-1", Contexts: []string{"tenant:blackorchid"}}, nil
+}
+
+func (testProvider) Model(context.Context, Principal) (Model, error) {
+	return Model{Provider: "test", Modes: []string{"rbac"}}, nil
+}
+
+func (testProvider) Policies(context.Context, Principal) ([]Policy, error) {
+	return []Policy{{ID: "policy-1", Resource: "cms.page", Action: "read", Effect: "allow"}}, nil
+}
+
+func (testProvider) AttributePolicies(context.Context, Principal) ([]AttributePolicy, error) {
+	return []AttributePolicy{{ID: "abac-1", Resource: "cms.page", Action: "read", Effect: "allow"}}, nil
+}
+
+func (testProvider) RelationTuples(context.Context, Principal) ([]RelationTuple, error) {
+	return []RelationTuple{{Subject: "user:admin-1", Relation: "member", Object: "tenant:blackorchid"}}, nil
+}
+
+func (testProvider) CheckRelation(context.Context, Principal, RelationCheck) (Decision, error) {
+	return Decision{Allowed: true, Reason: "matched relation"}, nil
+}
+
+func (testProvider) Enforce(context.Context, Principal, DecisionRequest) (Decision, error) {
+	return Decision{Allowed: true, Reason: "matched test rule"}, nil
+}

--- a/adminapi/handler_test.go
+++ b/adminapi/handler_test.go
@@ -31,12 +31,12 @@ func TestRouteCatalogContainsAuthzUIBackendEndpoints(t *testing.T) {
 	}
 }
 
-func TestNewHandlerRequiresPrincipalResolverAndAuthorizer(t *testing.T) {
+func TestNewHandlerRequiresRequiredAdapters(t *testing.T) {
 	_, err := NewHandler(Options{})
 	if err == nil {
 		t.Fatal("NewHandler without auth adapters succeeded")
 	}
-	for _, want := range []string{"PrincipalResolver", "Authorizer"} {
+	for _, want := range []string{"PrincipalResolver", "Authorizer", "Provider"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %s", err.Error(), want)
 		}
@@ -73,7 +73,7 @@ func TestHandlerDeniesUnauthenticatedAndUnauthorizedRequests(t *testing.T) {
 	}
 }
 
-func TestHandlerServesRolesScopesCapabilitiesAndDeclarations(t *testing.T) {
+func TestHandlerServesAuthzUIReadRoutes(t *testing.T) {
 	h := newTestHandler(t)
 
 	for _, tc := range []struct {
@@ -107,6 +107,44 @@ func TestHandlerServesRolesScopesCapabilitiesAndDeclarations(t *testing.T) {
 				if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 					t.Fatalf("decode object JSON: %v; body=%s", err, rec.Body.String())
 				}
+			}
+		})
+	}
+}
+
+func TestHandlerReturnsJSONErrorsForUnknownOrWrongMethodAdminAPIRequests(t *testing.T) {
+	h := newTestHandler(t)
+	for _, tc := range []struct {
+		name      string
+		method    string
+		path      string
+		wantCode  int
+		wantAllow string
+	}{
+		{name: "wrong method", method: http.MethodPut, path: "/api/authz/roles", wantCode: http.StatusMethodNotAllowed, wantAllow: "GET, POST, DELETE"},
+		{name: "unknown path", method: http.MethodGet, path: "/api/authz/missing", wantCode: http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Fatalf("Content-Type = %q, want application/json", got)
+			}
+			if tc.wantAllow != "" && rec.Header().Get("Allow") != tc.wantAllow {
+				t.Fatalf("Allow = %q, want %q", rec.Header().Get("Allow"), tc.wantAllow)
+			}
+			var payload struct {
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("decode JSON error: %v body=%s", err, rec.Body.String())
+			}
+			if payload.Error == "" {
+				t.Fatalf("error payload missing message: %s", rec.Body.String())
 			}
 		})
 	}

--- a/adminapi/handler_test.go
+++ b/adminapi/handler_test.go
@@ -77,18 +77,18 @@ func TestHandlerServesRolesScopesCapabilitiesAndDeclarations(t *testing.T) {
 	h := newTestHandler(t)
 
 	for _, tc := range []struct {
-		path string
-		key  string
+		path     string
+		wantType string
 	}{
-		{"/api/authz/roles", "roles"},
-		{"/api/authz/scopes", "scopes"},
-		{"/api/authz/capabilities", "capabilities"},
-		{"/api/authz/declarations", "declarations"},
-		{"/api/authz/projection-inputs", "projection_inputs"},
-		{"/api/authz/model", "model"},
-		{"/api/authz/policies", "policies"},
-		{"/api/authz/abac/policies", "policies"},
-		{"/api/authz/rebac/tuples", "tuples"},
+		{"/api/authz/roles", "array"},
+		{"/api/authz/scopes", "array"},
+		{"/api/authz/capabilities", "object"},
+		{"/api/authz/declarations", "object"},
+		{"/api/authz/projection-inputs", "object"},
+		{"/api/authz/model", "object"},
+		{"/api/authz/policies", "array"},
+		{"/api/authz/abac/policies", "array"},
+		{"/api/authz/rebac/tuples", "array"},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			rec := httptest.NewRecorder()
@@ -96,12 +96,45 @@ func TestHandlerServesRolesScopesCapabilitiesAndDeclarations(t *testing.T) {
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
 			}
-			var payload map[string]any
-			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-				t.Fatalf("decode JSON: %v", err)
+			switch tc.wantType {
+			case "array":
+				var payload []any
+				if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+					t.Fatalf("decode array JSON: %v; body=%s", err, rec.Body.String())
+				}
+			case "object":
+				var payload map[string]any
+				if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+					t.Fatalf("decode object JSON: %v; body=%s", err, rec.Body.String())
+				}
 			}
-			if _, ok := payload[tc.key]; !ok {
-				t.Fatalf("response for %s missing key %q: %s", tc.path, tc.key, rec.Body.String())
+		})
+	}
+}
+
+func TestHandlerSupportsAuthzUIMutationRoutes(t *testing.T) {
+	h := newTestHandler(t)
+	for _, tc := range []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, "/api/authz/roles", `{"user":"admin-1","role":"tenant_admin","context":"admin","scopes":["admin:authz.roles:read"]}`},
+		{http.MethodDelete, "/api/authz/roles", `{"user":"admin-1","role":"tenant_admin","context":"admin"}`},
+		{http.MethodPost, "/api/authz/policies", `{"subject":"admin","object":"cms.page","action":"read"}`},
+		{http.MethodDelete, "/api/authz/policies", `{"subject":"admin","object":"cms.page","action":"read"}`},
+		{http.MethodPost, "/api/authz/abac/policies", `{"id":"abac-1","resource":"cms.page","action":"read","effect":"allow"}`},
+		{http.MethodDelete, "/api/authz/abac/policies", `{"id":"abac-1","resource":"cms.page","action":"read","effect":"allow"}`},
+		{http.MethodPost, "/api/authz/rebac/tuples", `{"subject":"user:admin-1","relation":"member","object":"tenant:blackorchid"}`},
+		{http.MethodDelete, "/api/authz/rebac/tuples", `{"subject":"user:admin-1","relation":"member","object":"tenant:blackorchid"}`},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
 			}
 		})
 	}
@@ -197,6 +230,10 @@ func (testProvider) Roles(context.Context, Principal) ([]Role, error) {
 	return []Role{{Name: "tenant_admin", Scopes: []string{"cms.page.read"}}}, nil
 }
 
+func (testProvider) UpsertRole(context.Context, Principal, RoleAssignment) error { return nil }
+
+func (testProvider) DeleteRole(context.Context, Principal, RoleAssignment) error { return nil }
+
 func (testProvider) Scopes(context.Context, Principal) ([]Scope, error) {
 	return []Scope{{Name: "cms.page.read", Resource: "cms.page", Action: "read"}}, nil
 }
@@ -221,12 +258,32 @@ func (testProvider) Policies(context.Context, Principal) ([]Policy, error) {
 	return []Policy{{ID: "policy-1", Resource: "cms.page", Action: "read", Effect: "allow"}}, nil
 }
 
+func (testProvider) UpsertPolicy(context.Context, Principal, PolicyRule) error { return nil }
+
+func (testProvider) DeletePolicy(context.Context, Principal, PolicyRule) error { return nil }
+
 func (testProvider) AttributePolicies(context.Context, Principal) ([]AttributePolicy, error) {
 	return []AttributePolicy{{ID: "abac-1", Resource: "cms.page", Action: "read", Effect: "allow"}}, nil
 }
 
+func (testProvider) UpsertAttributePolicy(context.Context, Principal, AttributePolicy) error {
+	return nil
+}
+
+func (testProvider) DeleteAttributePolicy(context.Context, Principal, AttributePolicy) error {
+	return nil
+}
+
 func (testProvider) RelationTuples(context.Context, Principal) ([]RelationTuple, error) {
 	return []RelationTuple{{Subject: "user:admin-1", Relation: "member", Object: "tenant:blackorchid"}}, nil
+}
+
+func (testProvider) UpsertRelationTuple(context.Context, Principal, RelationTuple) error {
+	return nil
+}
+
+func (testProvider) DeleteRelationTuple(context.Context, Principal, RelationTuple) error {
+	return nil
 }
 
 func (testProvider) CheckRelation(context.Context, Principal, RelationCheck) (Decision, error) {

--- a/adminapi/types.go
+++ b/adminapi/types.go
@@ -1,0 +1,130 @@
+// Package adminapi exposes reusable HTTP handlers for authz administration UIs.
+package adminapi
+
+import (
+	"context"
+	"net/http"
+)
+
+type Options struct {
+	BasePath          string
+	PrincipalResolver PrincipalResolver
+	Authorizer        Authorizer
+	Provider          Provider
+}
+
+type Principal struct {
+	Subject string
+	Email   string
+	Role    string
+}
+
+type Role struct {
+	Name   string   `json:"name"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type Scope struct {
+	Name     string `json:"name"`
+	Context  string `json:"context,omitempty"`
+	Resource string `json:"resource,omitempty"`
+	Action   string `json:"action,omitempty"`
+}
+
+type Capability struct {
+	Name      string `json:"name"`
+	Supported bool   `json:"supported"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type ResourceDeclaration struct {
+	Name    string   `json:"name"`
+	Actions []string `json:"actions,omitempty"`
+}
+
+type Declarations struct {
+	Resources []ResourceDeclaration `json:"resources,omitempty"`
+}
+
+type ProjectionInputs struct {
+	Subject  string   `json:"subject,omitempty"`
+	Contexts []string `json:"contexts,omitempty"`
+}
+
+type Model struct {
+	Provider string   `json:"provider,omitempty"`
+	Modes    []string `json:"modes,omitempty"`
+}
+
+type Policy struct {
+	ID       string `json:"id"`
+	Resource string `json:"resource,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Effect   string `json:"effect,omitempty"`
+}
+
+type AttributePolicy struct {
+	ID       string `json:"id"`
+	Resource string `json:"resource,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Effect   string `json:"effect,omitempty"`
+}
+
+type RelationTuple struct {
+	Subject  string `json:"subject"`
+	Relation string `json:"relation"`
+	Object   string `json:"object"`
+}
+
+type RelationCheck struct {
+	Subject  string `json:"subject"`
+	Relation string `json:"relation"`
+	Object   string `json:"object"`
+}
+
+type DecisionRequest struct {
+	Subject  string `json:"subject"`
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Context  string `json:"context,omitempty"`
+	Scope    string `json:"scope,omitempty"`
+}
+
+type Decision struct {
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type PrincipalResolver interface {
+	CurrentPrincipal(*http.Request) (Principal, bool)
+}
+
+type Authorizer interface {
+	Authorize(context.Context, Principal, string, string) error
+}
+
+type Provider interface {
+	Roles(context.Context, Principal) ([]Role, error)
+	Scopes(context.Context, Principal) ([]Scope, error)
+	Capabilities(context.Context, Principal) ([]Capability, error)
+	Declarations(context.Context, Principal) (Declarations, error)
+	ProjectionInputs(context.Context, Principal) (ProjectionInputs, error)
+	Model(context.Context, Principal) (Model, error)
+	Policies(context.Context, Principal) ([]Policy, error)
+	AttributePolicies(context.Context, Principal) ([]AttributePolicy, error)
+	RelationTuples(context.Context, Principal) ([]RelationTuple, error)
+	CheckRelation(context.Context, Principal, RelationCheck) (Decision, error)
+	Enforce(context.Context, Principal, DecisionRequest) (Decision, error)
+}
+
+type RouteCatalog struct {
+	ByPath map[string]Route
+}
+
+type Route struct {
+	Name     string
+	Method   string
+	Path     string
+	Resource string
+	Action   string
+}

--- a/adminapi/types.go
+++ b/adminapi/types.go
@@ -24,6 +24,13 @@ type Role struct {
 	Scopes []string `json:"scopes,omitempty"`
 }
 
+type RoleAssignment struct {
+	User    string   `json:"user"`
+	Role    string   `json:"role"`
+	Context string   `json:"context,omitempty"`
+	Scopes  []string `json:"scopes,omitempty"`
+}
+
 type Scope struct {
 	Name     string `json:"name"`
 	Context  string `json:"context,omitempty"`
@@ -61,6 +68,12 @@ type Policy struct {
 	Resource string `json:"resource,omitempty"`
 	Action   string `json:"action,omitempty"`
 	Effect   string `json:"effect,omitempty"`
+}
+
+type PolicyRule struct {
+	Subject string `json:"subject"`
+	Object  string `json:"object"`
+	Action  string `json:"action"`
 }
 
 type AttributePolicy struct {
@@ -105,14 +118,22 @@ type Authorizer interface {
 
 type Provider interface {
 	Roles(context.Context, Principal) ([]Role, error)
+	UpsertRole(context.Context, Principal, RoleAssignment) error
+	DeleteRole(context.Context, Principal, RoleAssignment) error
 	Scopes(context.Context, Principal) ([]Scope, error)
 	Capabilities(context.Context, Principal) ([]Capability, error)
 	Declarations(context.Context, Principal) (Declarations, error)
 	ProjectionInputs(context.Context, Principal) (ProjectionInputs, error)
 	Model(context.Context, Principal) (Model, error)
 	Policies(context.Context, Principal) ([]Policy, error)
+	UpsertPolicy(context.Context, Principal, PolicyRule) error
+	DeletePolicy(context.Context, Principal, PolicyRule) error
 	AttributePolicies(context.Context, Principal) ([]AttributePolicy, error)
+	UpsertAttributePolicy(context.Context, Principal, AttributePolicy) error
+	DeleteAttributePolicy(context.Context, Principal, AttributePolicy) error
 	RelationTuples(context.Context, Principal) ([]RelationTuple, error)
+	UpsertRelationTuple(context.Context, Principal, RelationTuple) error
+	DeleteRelationTuple(context.Context, Principal, RelationTuple) error
 	CheckRelation(context.Context, Principal, RelationCheck) (Decision, error)
 	Enforce(context.Context, Principal, DecisionRequest) (Decision, error)
 }


### PR DESCRIPTION
## Summary
- add reusable adminapi handler package for authz UI backend routes
- add typed provider/authn/authz adapters and route catalog
- document host mounting and server-side authorization behavior

## Verification
- RED: `GOWORK=off go test ./adminapi -run Test -count=1` initially failed on missing Principal/Role/Scope/adminapi types
- GREEN: `GOWORK=off go test ./adminapi -run Test -count=1`
- GREEN: `GOWORK=off go test ./...`

Part of locked multisite plan: docs/plans/2026-06-21-reusable-admin-identity-authz.md