### PR TITLE
Add lightweight authz contract module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,14 @@ jobs:
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Resolve dependencies
-        run: go mod tidy
+        run: |
+          go mod tidy
+          (cd authzcontract && go mod tidy)
 
       - name: Run go vet
-        run: go vet ./...
+        run: |
+          go vet ./...
+          (cd authzcontract && go vet ./...)
 
       - name: Run go fmt check
         run: |
@@ -55,10 +59,14 @@ jobs:
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Resolve dependencies
-        run: go mod tidy
+        run: |
+          go mod tidy
+          (cd authzcontract && go mod tidy)
 
       - name: Run tests
-        run: go test ./... -v -race
+        run: |
+          go test ./... -v -race
+          (cd authzcontract && go test ./... -v -race)
 
   build:
     name: Cross-platform Build

--- a/authzcontract/go.mod
+++ b/authzcontract/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoCodeAlone/workflow-plugin-authz/authzcontract
+
+go 1.26.4

--- a/authzcontract/policy_contract.go
+++ b/authzcontract/policy_contract.go
@@ -1,0 +1,75 @@
+package authzcontract
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	CasbinModuleType = "authz.casbin"
+	EffectAllow      = "allow"
+	EffectDeny       = "deny"
+)
+
+// CasbinPolicyConfig is the public JSON/YAML contract for hosts that consume
+// authz.casbin policy shape without importing plugin internals.
+type CasbinPolicyConfig struct {
+	Type                 string              `json:"type,omitempty" yaml:"type,omitempty"`
+	Config               *CasbinPolicyConfig `json:"config,omitempty" yaml:"config,omitempty"`
+	Model                string              `json:"model,omitempty" yaml:"model,omitempty"`
+	DefaultEffect        string              `json:"default_effect,omitempty" yaml:"default_effect,omitempty"`
+	Policies             [][]string          `json:"policies,omitempty" yaml:"policies,omitempty"`
+	RoleAssignments      [][]string          `json:"role_assignments,omitempty" yaml:"role_assignments,omitempty"`
+	RoleAssignmentsCamel [][]string          `json:"roleAssignments,omitempty" yaml:"roleAssignments,omitempty"`
+}
+
+func NormalizeCasbinPolicyConfig(policy CasbinPolicyConfig) (CasbinPolicyConfig, error) {
+	policy.Type = strings.TrimSpace(policy.Type)
+	if policy.Type == "" {
+		policy.Type = CasbinModuleType
+	}
+	if policy.Type != CasbinModuleType {
+		return CasbinPolicyConfig{}, fmt.Errorf("unsupported authorization policy type %q", policy.Type)
+	}
+	policy.Model = strings.TrimSpace(policy.Model)
+	policy.DefaultEffect = normalizeEffect(policy.DefaultEffect)
+	policy.Policies = cloneStringRows(policy.Policies)
+	policy.RoleAssignments = append(cloneStringRows(policy.RoleAssignments), cloneStringRows(policy.RoleAssignmentsCamel)...)
+	policy.RoleAssignmentsCamel = nil
+	if policy.Config == nil {
+		return policy, nil
+	}
+	config, err := NormalizeCasbinPolicyConfig(*policy.Config)
+	if err != nil {
+		return CasbinPolicyConfig{}, err
+	}
+	policy.Config = nil
+	if config.Model != "" {
+		policy.Model = config.Model
+	}
+	if config.DefaultEffect != "" {
+		policy.DefaultEffect = config.DefaultEffect
+	}
+	policy.Policies = append(policy.Policies, config.Policies...)
+	policy.RoleAssignments = append(policy.RoleAssignments, config.RoleAssignments...)
+	return policy, nil
+}
+
+func normalizeEffect(effect string) string {
+	switch strings.ToLower(strings.TrimSpace(effect)) {
+	case EffectAllow:
+		return EffectAllow
+	case EffectDeny:
+		return EffectDeny
+	default:
+		return ""
+	}
+}
+
+func cloneStringRows(rows [][]string) [][]string {
+	out := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, append([]string(nil), row...))
+	}
+	return out
+}

--- a/authzcontract/policy_contract.go
+++ b/authzcontract/policy_contract.go
@@ -29,7 +29,7 @@ func NormalizeCasbinPolicyConfig(policy CasbinPolicyConfig) (CasbinPolicyConfig,
 		policy.Type = CasbinModuleType
 	}
 	if policy.Type != CasbinModuleType {
-		return CasbinPolicyConfig{}, fmt.Errorf("unsupported authorization policy type %q", policy.Type)
+		return CasbinPolicyConfig{}, fmt.Errorf("unsupported authorization policy type %q (supported: %q)", policy.Type, CasbinModuleType)
 	}
 	policy.Model = strings.TrimSpace(policy.Model)
 	policy.DefaultEffect = normalizeEffect(policy.DefaultEffect)

--- a/authzcontract/policy_contract_test.go
+++ b/authzcontract/policy_contract_test.go
@@ -33,7 +33,7 @@ func TestPublicCasbinPolicyContractNormalizesPluginWrapper(t *testing.T) {
 		t.Fatalf("Config should be flattened after normalization: %+v", got.Config)
 	}
 	if got.Model != "workflow-compute-rbac" {
-		t.Fatalf("Model=%q", got.Model)
+		t.Fatalf("Model=%q, want %q", got.Model, "workflow-compute-rbac")
 	}
 	if got.DefaultEffect != EffectDeny {
 		t.Fatalf("DefaultEffect=%q, want %q", got.DefaultEffect, EffectDeny)

--- a/authzcontract/policy_contract_test.go
+++ b/authzcontract/policy_contract_test.go
@@ -1,0 +1,69 @@
+package authzcontract
+
+import "testing"
+
+func TestPublicCasbinPolicyContractNormalizesPluginWrapper(t *testing.T) {
+	got, err := NormalizeCasbinPolicyConfig(CasbinPolicyConfig{
+		Type:          CasbinModuleType,
+		DefaultEffect: EffectDeny,
+		Policies: [][]string{
+			{"dashboard-admin", "/v1/dashboard/*", "GET"},
+		},
+		RoleAssignmentsCamel: [][]string{
+			{"alice", "dashboard-admin"},
+		},
+		Config: &CasbinPolicyConfig{
+			Model:         "workflow-compute-rbac",
+			DefaultEffect: "",
+			Policies: [][]string{
+				{"operator", "/v1/provider-contracts", "POST", EffectAllow},
+			},
+			RoleAssignments: [][]string{
+				{"bob", "operator"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeCasbinPolicyConfig: %v", err)
+	}
+	if got.Type != CasbinModuleType {
+		t.Fatalf("Type=%q, want %q", got.Type, CasbinModuleType)
+	}
+	if got.Config != nil {
+		t.Fatalf("Config should be flattened after normalization: %+v", got.Config)
+	}
+	if got.Model != "workflow-compute-rbac" {
+		t.Fatalf("Model=%q", got.Model)
+	}
+	if got.DefaultEffect != EffectDeny {
+		t.Fatalf("DefaultEffect=%q, want %q", got.DefaultEffect, EffectDeny)
+	}
+	if len(got.Policies) != 2 {
+		t.Fatalf("Policies=%+v, want parent and nested policies", got.Policies)
+	}
+	if len(got.RoleAssignments) != 2 {
+		t.Fatalf("RoleAssignments=%+v, want camel and nested role assignments", got.RoleAssignments)
+	}
+}
+
+func TestPublicCasbinPolicyContractRejectsUnsupportedType(t *testing.T) {
+	_, err := NormalizeCasbinPolicyConfig(CasbinPolicyConfig{Type: "authz.other"})
+	if err == nil {
+		t.Fatal("expected unsupported policy type to fail")
+	}
+}
+
+func TestPublicCasbinPolicyContractNestedConfigOverridesWrapperDefaultEffect(t *testing.T) {
+	got, err := NormalizeCasbinPolicyConfig(CasbinPolicyConfig{
+		DefaultEffect: EffectAllow,
+		Config: &CasbinPolicyConfig{
+			DefaultEffect: EffectDeny,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeCasbinPolicyConfig: %v", err)
+	}
+	if got.DefaultEffect != EffectDeny {
+		t.Fatalf("DefaultEffect=%q, want nested %q", got.DefaultEffect, EffectDeny)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `authzcontract` as a nested, dependency-light Go module for the shared `authz.casbin` policy contract.
- Exposes the CASBIN module/effect constants and policy normalizer without importing the heavy plugin implementation package.
- Updates CI to tidy, vet, and test the nested module explicitly so the new public contract is covered.

## Scope
Workspace slimming plan PR group 2 precursor: shared admin/auth/authz residual cleanup. This extracts the reusable authz policy contract into the authz plugin repo so workflow-compute can consume plugin-owned contract shape without app-owned literals or provider-style implementation imports.

## Verification
- `GOWORK=off go mod tidy && (cd authzcontract && GOWORK=off go mod tidy) && GOWORK=off go vet ./... && (cd authzcontract && GOWORK=off go vet ./...)`
- `GOWORK=off go test ./... -count=1 && (cd authzcontract && GOWORK=off go test ./... -count=1)`

## Regression Proof
With nested-default fix reverted:

```sh
$ GOWORK=off go test ./... -run 'TestPublicCasbinPolicyContractNestedConfigOverridesWrapperDefaultEffect' -count=1
FAIL — DefaultEffect="allow", want nested "deny"
```

With fix restored:

```sh
$ GOWORK=off go test ./... -run 'TestPublicCasbinPolicyContractNestedConfigOverridesWrapperDefaultEffect' -count=1
PASS
```

Doc-reconciliation: clean

Generated by the implementing agent.