### PR TITLE
Reject invalid authz default effects

### DIFF
--- a/authzcontract/policy_contract.go
+++ b/authzcontract/policy_contract.go
@@ -32,7 +32,11 @@ func NormalizeCasbinPolicyConfig(policy CasbinPolicyConfig) (CasbinPolicyConfig,
 		return CasbinPolicyConfig{}, fmt.Errorf("unsupported authorization policy type %q (supported: %q)", policy.Type, CasbinModuleType)
 	}
 	policy.Model = strings.TrimSpace(policy.Model)
-	policy.DefaultEffect = normalizeEffect(policy.DefaultEffect)
+	rawDefaultEffect := strings.TrimSpace(policy.DefaultEffect)
+	policy.DefaultEffect = normalizeEffect(rawDefaultEffect)
+	if rawDefaultEffect != "" && policy.DefaultEffect == "" {
+		return CasbinPolicyConfig{}, fmt.Errorf("unsupported default_effect %q (supported: %q or %q)", rawDefaultEffect, EffectAllow, EffectDeny)
+	}
 	policy.Policies = cloneStringRows(policy.Policies)
 	policy.RoleAssignments = append(cloneStringRows(policy.RoleAssignments), cloneStringRows(policy.RoleAssignmentsCamel)...)
 	policy.RoleAssignmentsCamel = nil

--- a/authzcontract/policy_contract_test.go
+++ b/authzcontract/policy_contract_test.go
@@ -53,6 +53,13 @@ func TestPublicCasbinPolicyContractRejectsUnsupportedType(t *testing.T) {
 	}
 }
 
+func TestPublicCasbinPolicyContractRejectsUnsupportedDefaultEffect(t *testing.T) {
+	_, err := NormalizeCasbinPolicyConfig(CasbinPolicyConfig{DefaultEffect: "bananas"})
+	if err == nil {
+		t.Fatal("expected unsupported default effect to fail")
+	}
+}
+
 func TestPublicCasbinPolicyContractNestedConfigOverridesWrapperDefaultEffect(t *testing.T) {
 	got, err := NormalizeCasbinPolicyConfig(CasbinPolicyConfig{
 		DefaultEffect: EffectAllow,


### PR DESCRIPTION
## Summary
- Makes the lightweight `authzcontract` normalizer reject unsupported non-empty `default_effect` values instead of clearing them.
- Adds a regression test for malformed `default_effect` input.

## Context
The workflow-compute consumer caught this during full-suite verification: `COMPUTE_AUTHZ_POLICY_FILE` with `default_effect: bananas` was accepted because v0.1.0 normalized the value to empty before the host enforcer could reject it. The fail-closed behavior belongs in the shared contract.

## Verification
- `GOWORK=off go vet ./... && (cd authzcontract && GOWORK=off go vet ./...)`
- `GOWORK=off go test ./... -count=1 && (cd authzcontract && GOWORK=off go test ./... -count=1)`

## Regression Proof
Before the fix:

```sh
$ GOWORK=off go test ./... -run 'TestPublicCasbinPolicyContractRejectsUnsupportedDefaultEffect' -count=1
FAIL — expected unsupported default effect to fail
```

After the fix:

```sh
$ GOWORK=off go test ./... -run 'TestPublicCasbinPolicyContractRejectsUnsupportedDefaultEffect' -count=1
PASS
```

Doc-reconciliation: clean

Generated by the implementing agent.